### PR TITLE
Invert the order of importing django.forms.utils

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,6 +224,7 @@ The following people have been of help, in some capacity.
    fixing an omission in the setup script.
  * `Francois Lebel`_, for various fixes.
  * `Jussi Räsänen`_, for various fixes.
+ * Vadim Markovtsev, for minor fix related to Django 1.8+.
 
 TODO
 ----

--- a/haystackbrowser/forms.py
+++ b/haystackbrowser/forms.py
@@ -7,9 +7,9 @@ from django.forms import (MultipleChoiceField, CheckboxSelectMultiple,
                           ChoiceField, HiddenInput, IntegerField)
 from django.utils.translation import ugettext_lazy as _
 try:
-    from django.forms.util import ErrorDict
-except ImportError: # > Django 1.9
     from django.forms.utils import ErrorDict
+except ImportError: # < Django 1.8
+    from django.forms.util import ErrorDict
 try:
     from django.utils.encoding import force_text
 except ImportError:  # < Django 1.5


### PR DESCRIPTION
Since recent stable Django 1.8 gives a RemovedInDjango19Warning, let's first try to import the renamed package and then the old one.