### PR TITLE
cleanse settings values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@
 .. _David Novakovic: http://blog.dpn.name/
 .. _Francois Lebel: http://flebel.com/
 .. _Jussi Räsänen: http://skyred.fi/
+.. _Michaël Krens: https://github.com/michi88/
 .. _REPL to inspect the SearchQuerySet: http://django-haystack.readthedocs.org/en/latest/debugging.html#no-results-found-on-the-web-page
 .. _ticket 21056: https://code.djangoproject.com/ticket/21056
 .. _tagged on GitHub: https://github.com/kezabelle/django-haystackbrowser/tags
@@ -269,6 +270,7 @@ The following people have been of help, in some capacity.
  * `Francois Lebel`_, for various fixes.
  * `Jussi Räsänen`_, for various fixes.
  * Vadim Markovtsev, for minor fix related to Django 1.8+.
+ * `Michaël Krens`_, for various fixes.
 
 TODO
 ----

--- a/haystackbrowser/utils.py
+++ b/haystackbrowser/utils.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 import re
+import sys
+PY3 = sys.version_info[0] == 3
+if PY3:
+    string_types = str,
+else:
+    string_types = basestring,
 from django.conf import settings
 from django.core.management.commands.diffsettings import module_to_dict
 import logging
@@ -132,6 +138,8 @@ class HaystackConfig(object):
 
 def cleanse_setting_value(setting_value):
     """ do not show user:pass in https://user:pass@domain.com settings values """
+    if not isinstance(setting_value, string_types):
+        return setting_value
     return re.sub(r'//(.*:.*)@', '//********:********@', setting_value)
 
 


### PR DESCRIPTION
I think we shouldn't show the username and password part of the backend url (if that exists) of the haystack settings in the admin

`URL: https://user:pass@domain.com --> https://********:********@domain.com`
